### PR TITLE
Alters vlfi to respect the default-directory variable when opening

### DIFF
--- a/vlfi.el
+++ b/vlfi.el
@@ -96,6 +96,7 @@ buffer.  You can customize number of bytes displayed by customizing
 `vlfi-batch-size'."
   (interactive "fFile to open: ")
   (with-current-buffer (generate-new-buffer "*vlfi*")
+    (setq default-directory (file-name-directory (expand-file-name file)))
     (vlfi-mode)
     (setq buffer-file-name file
           vlfi-file-size (vlfi-get-file-size file))


### PR DESCRIPTION
When using vlfi, the default-directory of the vlfi-mode buffer is whatever default-directory was in the buffer you had open when the vlfi command was called. 

This fixes that by setting default-directory with the *vlfi* buffer.
