### PR TITLE
Fix cursor position after search

### DIFF
--- a/vlf-search.el
+++ b/vlf-search.el
@@ -140,10 +140,10 @@ Return t if search has been at least partially successful."
        (let ((result
               (if backward
                   (vlf-goto-match match-chunk-start match-chunk-end
-                                  match-end-pos match-start-pos
+                                  match-start-pos match-end-pos
                                   count to-find time highlight)
                 (vlf-goto-match match-chunk-start match-chunk-end
-                                match-start-pos match-end-pos
+                                match-end-pos match-start-pos
                                 count to-find time highlight))))
          (run-hook-with-args 'vlf-after-batch-functions 'search)
          result)))))


### PR DESCRIPTION
After searching forward (resp. backward) the cursor should be at the
end (resp. the beginning) of the match. That way one can jump to the
next match by running again the command.