### PR TITLE
Issue 35: make mode-line batch indicators more accurate

### DIFF
--- a/vlf.el
+++ b/vlf.el
@@ -109,8 +109,8 @@ values are: `write', `ediff', `occur', `search', `goto-line'."
   "Mode to browse large files in."
   :group 'vlf :keymap vlf-prefix-map
   :lighter (:eval (format " VLF[%d/%d](%s)"
-                          (/ vlf-end-pos vlf-batch-size)
-                          (/ vlf-file-size vlf-batch-size)
+                          (ceiling vlf-end-pos vlf-batch-size)
+                          (ceiling vlf-file-size vlf-batch-size)
                           (file-size-human-readable vlf-file-size)))
   (cond (vlf-mode
          (set (make-local-variable 'require-final-newline) nil)


### PR DESCRIPTION
With this change, opening a file e.g. of size 101 MB with a chunk size of 50 MB:

Position MB  ->   mode-line
     0    ->      1/3
   49    ->      1/3
   50    ->      1/3
   51    ->      2/3
  100   ->      2/3
  101   ->      3/3
