### PR TITLE
fixed large-file-warning-threshold error

### DIFF
--- a/vlf-tune.el
+++ b/vlf-tune.el
@@ -60,7 +60,9 @@ but don't change batch size.  If t, measure and change."
                                (if ram-size
                                    (/ ram-size 20)
                                  0))
-                             large-file-warning-threshold)
+                             (if large-file-warning-threshold
+                                 large-file-warning-threshold
+                               0))
   "Maximum batch size in bytes when auto tuning.
 Avoid increasing this after opening file with VLF."
   :group 'vlf :type 'integer)


### PR DESCRIPTION
The docstring for `large-file-warning-threshold` states
```
Maximum size of file above which a confirmation is requested.
When nil, never request confirmation.
```
however when the variable is `nil`, `vlf-tune` fails to load because it tries to call max with `nil` as one of the arguments. This fixes that issue.